### PR TITLE
エラーハンドリングの整理

### DIFF
--- a/back/src/api/app.go
+++ b/back/src/api/app.go
@@ -13,3 +13,11 @@ func Ping(c *gin.Context) {
 func NoRoute(c *gin.Context) {
 	c.String(http.StatusNotFound, "Invalid Path (%s)", c.Request.URL.Path)
 }
+
+func abortWithError(c *gin.Context, status int, code string, err error) {
+	c.AbortWithError(status, err).SetMeta(gin.H{"code": code})
+}
+
+func abortWithJSON(c *gin.Context, status int, code string) {
+	c.AbortWithStatusJSON(status, gin.H{"code": code})
+}

--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -5,17 +5,16 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/SongCastle/KoR/model"
+	"github.com/SongCastle/KoR/ecode"
 	"github.com/SongCastle/KoR/lib/jwt"
+	"github.com/SongCastle/KoR/model"
 	"github.com/gin-gonic/gin"
 )
 
 func ShowUsers(c *gin.Context) {
 	users, err := model.GetUsers(responseKeys())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToGetUsers, err)
 		return
 	}
 	c.JSON(http.StatusOK, &users)
@@ -24,23 +23,17 @@ func ShowUsers(c *gin.Context) {
 func ShowUser(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Blank ID",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.BlankUserID)
 		return
 	}
 	_id, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invaid ID",
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidUserID, err)
 		return
 	}
 	user, err := model.GetUser(&model.UserGetQuery{ID: _id}, responseKeys())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToGetUser, err)
 		return
 	}
 	c.JSON(http.StatusOK, user)
@@ -49,18 +42,15 @@ func ShowUser(c *gin.Context) {
 func CreateUser(c *gin.Context) {
 	var newUser model.NewUser
 	if err := c.ShouldBindJSON(&newUser); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidCreateUserParams, err)
 		return
 	}
 	user, err := model.CreateUser(&newUser)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToCreateUser, err)
 		return
 	}
+	// TODO: 返却する field の選択
 	c.JSON(http.StatusCreated, user)
 }
 
@@ -70,62 +60,46 @@ func UpdateUser(c *gin.Context) {
 	// Authorization ヘッダを確認
 	authHeader := c.Request.Header.Get("Authorization")
 	if authHeader == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"message": "Unauthorized",
-		})
+		abortWithJSON(c, http.StatusUnauthorized, ecode.BlankAuthHeader)
 		return
 	}
 	auth := strings.Split(authHeader, "Bearer ")
 	authLen := len(auth)
 	if authLen < 2 {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invalid Authorization Header",
-		})
+		abortWithJSON(c, http.StatusUnauthorized, ecode.InvalidAuthHeader)
 		return
 	}
 	// 対象の User ID を取得
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Blank ID",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.BlankUserID)
 		return
 	}
 	_id, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invaid ID",
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidUserID, err)
 		return
 	}
 	// Authorization Token を取得・検証
 	token := strings.TrimSpace(auth[authLen - 1])
 	ok, err := jwt.Validate(token, _id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToValidateAuthToken, err)
 		return
 	}
 	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invalid Authorization Token",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.InvalidAuthToken)
 		return
 	}
 	// ユーザ更新
 	var newUser model.NewUser
 	if err := c.ShouldBindJSON(&newUser); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidUpdateUserParams, err)
 		return
 	}
 	user, err := model.UpdateUser(_id, &newUser)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToUpdateUser, err)
 		return
 	}
 	c.JSON(http.StatusOK, user)
@@ -134,22 +108,16 @@ func UpdateUser(c *gin.Context) {
 func DeleteUser(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Blank ID",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.BlankUserID)
 		return
 	}
 	_id, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invaid ID",
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidUserID, err)
 		return
 	}
 	if err := model.DeleteUser(_id); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToDeleteUser, err)
 		return
 	}
 	c.String(http.StatusOK, "deleted")
@@ -164,22 +132,16 @@ type AuthParams struct {
 func AuthUser(c *gin.Context) {
 	var params AuthParams
 	if err := c.ShouldBindJSON(&params); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": err.Error(),
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.InvalidAuthUserParams, err)
 		return
 	}
 
 	if params.Login == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Blank Login",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.BlankLogin)
 		return
 	}
 	if params.Password == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Blank Password",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.BlankPassword)
 		return
 	}
 
@@ -188,24 +150,18 @@ func AuthUser(c *gin.Context) {
 		[]string{"id", "encrypted_password", "login", "password_salt"},
 	)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invalid",
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToAuth, err)
 		return
 	}
 	// Password の検証
 	if !user.ValidPassword(params.Password) {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Invalid",
-		})
+		abortWithJSON(c, http.StatusBadRequest, ecode.FailToAuth)
 		return
 	}
 	// JWT Token 生成
 	token, err := jwt.Generate(user.ID, user.Login)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Failed to generate token",
-		})
+		abortWithError(c, http.StatusBadRequest, ecode.FailToGenerateAuthToken, err)
 		return
 	}
 	c.String(http.StatusOK, token)

--- a/back/src/cmd/app/main.go
+++ b/back/src/cmd/app/main.go
@@ -29,7 +29,7 @@ func load() error {
 	return nil
 }
 
-func errorMiddleware() gin.HandlerFunc {
+func errorHandleMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next()
 		if err := c.Errors.Last(); err != nil {
@@ -63,7 +63,7 @@ func serve() {
 	v1.GET("/ping", api.Ping)
 
 	// Users API
-	v1.Use(errorMiddleware())
+	v1.Use(errorHandleMiddleware())
 	{
 		v1.GET("/users", api.ShowUsers)
 		v1.GET("/users/:id", api.ShowUser)

--- a/back/src/ecode/ecode.go
+++ b/back/src/ecode/ecode.go
@@ -1,0 +1,22 @@
+package ecode
+
+const (
+	FailToGetUsers          = "fail_to_get_users"
+	BlankUserID             = "blank_user_id"
+	InvalidUserID           = "invalid_user_id_format"
+	FailToGetUser           = "fail_to_get_user"
+	InvalidCreateUserParams = "invalid_create_user_params"
+	FailToCreateUser        = "fail_to_create_user"
+	BlankAuthHeader         = "blank_authorization_header"
+	InvalidAuthHeader       = "Invalid_authorization_header_format"
+	FailToValidateAuthToken = "fail_to_validate_authorization_token"
+	InvalidAuthToken        = "invalid_authorization_token_format"
+	InvalidUpdateUserParams = "invalid_update_user_params"
+	FailToUpdateUser        = "fail_to_update_user"
+	FailToDeleteUser        = "fail_to_delete_user"
+	InvalidAuthUserParams   = "invalid_authorize_user_params"
+	BlankLogin              = "blank_login"
+	BlankPassword           = "blank_password"
+	FailToAuth              = "invalid_login_or_password"
+	FailToGenerateAuthToken = "fail_to_generate_authorization_token"
+)

--- a/back/src/lib/jwt/jwt.go
+++ b/back/src/lib/jwt/jwt.go
@@ -71,7 +71,7 @@ func Validate(tokenString string, userID uint64) (bool, error) {
 }
 
 func parse(tokenString string) (*jwt.Token, error) {
-	return jwt.ParseWithClaims(tokenString, &CustomClaims{},  func(t *jwt.Token) (interface{}, error) {
+	return jwt.ParseWithClaims(tokenString, &CustomClaims{}, func(t *jwt.Token) (interface{}, error) {
 		return []byte(jwtSecret), nil
 	})
 }


### PR DESCRIPTION
**CAUTION: マージ先を変更する !!**

## 概要
エラーハンドリングの方法を整理しました。

- クライアントへ返却する値をエラーコードへ統一
- エラーハンドリング用のミドルウェアを追加
	- レスポンスの整形のため
	- エラー内容のロギングのため

### 仕様変更点
今後、バックエンドにてエラーが発生した場合、エラーコードが返却されるようになります。

- エラーコード返却例
```
# 認証に失敗した場合 (パスワードが不正)
curl -X PUT 0.0.0.0:3000/v1/users/auth -H "Content-Type: application/json" -d '{"login": "user-login", "password": "invalid!!!"}'
> {"code":"invalid_login_or_password"}

# 認証なしで、ユーザ更新しようとした場合 (Authorization ヘッダ未指定)
curl -X PUT 0.0.0.0:3000/v1/users/4 -H "Content-Type: application/json" -d '{"password": new!!!"}'
> {"code":"blank_authorization_header"}
```

エラーコードの一覧は [こちら](https://github.com/SongCastle/KoR/blob/error-handling/back/src/ecode/ecode.go) に記載しております。

## 確認事項
リクエスト失敗時、エラーコードが返却されること
(「エラーコード返却例」のような動作となること)