### PR TITLE
認証用ミドルウェアの追加

### DIFF
--- a/back/src/api/app.go
+++ b/back/src/api/app.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/SongCastle/KoR/ecode"
 	"github.com/gin-gonic/gin"
 )
 
@@ -15,9 +16,9 @@ func NoRoute(c *gin.Context) {
 }
 
 func abortWithError(c *gin.Context, status int, code string, err error) {
-	c.AbortWithError(status, err).SetMeta(gin.H{"code": code})
+	c.AbortWithError(status, err).SetMeta(ecode.CodeJson(code))
 }
 
 func abortWithJSON(c *gin.Context, status int, code string) {
-	c.AbortWithStatusJSON(status, gin.H{"code": code})
+	c.AbortWithStatusJSON(status, ecode.CodeJson(code))
 }

--- a/back/src/ecode/ecode.go
+++ b/back/src/ecode/ecode.go
@@ -1,22 +1,32 @@
 package ecode
 
-const (
-	FailToGetUsers          = "fail_to_get_users"
-	BlankUserID             = "blank_user_id"
-	InvalidUserID           = "invalid_user_id_format"
-	FailToGetUser           = "fail_to_get_user"
-	InvalidCreateUserParams = "invalid_create_user_params"
-	FailToCreateUser        = "fail_to_create_user"
-	BlankAuthHeader         = "blank_authorization_header"
-	InvalidAuthHeader       = "Invalid_authorization_header_format"
-	FailToValidateAuthToken = "fail_to_validate_authorization_token"
-	InvalidAuthToken        = "invalid_authorization_token_format"
-	InvalidUpdateUserParams = "invalid_update_user_params"
-	FailToUpdateUser        = "fail_to_update_user"
-	FailToDeleteUser        = "fail_to_delete_user"
-	InvalidAuthUserParams   = "invalid_authorize_user_params"
-	BlankLogin              = "blank_login"
-	BlankPassword           = "blank_password"
-	FailToAuth              = "invalid_login_or_password"
-	FailToGenerateAuthToken = "fail_to_generate_authorization_token"
-)
+import "github.com/gin-gonic/gin"
+
+var codeTable map[string]string = map[string]string{
+	"FailToGetUsers"         : "fail_to_get_users",
+	"BlankUserID"            : "blank_user_id",
+	"InvalidUserID"          : "invalid_user_id_format",
+	"FailToGetUser"          : "fail_to_get_user",
+	"InvalidCreateUserParams": "invalid_create_user_params",
+	"FailToCreateUser"       : "fail_to_create_user",
+	"BlankAuthHeader"        : "blank_authorization_header",
+	"InvalidAuthHeader"      : "Invalid_authorization_header_format",
+	"FailToValidateAuthToken": "fail_to_validate_authorization_token",
+	"InvalidAuthToken"       : "invalid_authorization_token_format",
+	"InvalidUpdateUserParams": "invalid_update_user_params",
+	"FailToUpdateUser"       : "fail_to_update_user",
+	"FailToDeleteUser"       : "fail_to_delete_user",
+	"InvalidAuthUserParams"  : "invalid_authorize_user_params",
+	"BlankLogin"             : "blank_login",
+	"BlankPassword"          : "blank_password",
+	"FailToAuth"             : "invalid_login_or_password",
+	"FailToGenerateAuthToken": "fail_to_generate_authorization_token",
+}
+
+func CodeJson(key string) gin.H {
+	code, ok := codeTable[key]
+	if !ok {
+		code = "unknown"
+	}
+	return gin.H{"code": code}
+}

--- a/back/src/lib/lib.go
+++ b/back/src/lib/lib.go
@@ -1,0 +1,11 @@
+package lib
+
+import (
+	"github.com/SongCastle/KoR/lib/encryptor"
+	"github.com/SongCastle/KoR/lib/jwt"
+)
+
+func SetUp() {
+	encryptor.Init()
+	jwt.Init()
+}

--- a/back/src/middleware/auth.go
+++ b/back/src/middleware/auth.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/SongCastle/KoR/ecode"
+	"github.com/SongCastle/KoR/lib/jwt"
+	"github.com/SongCastle/KoR/model"
+	"github.com/gin-gonic/gin"
+)
+
+const AuthorizationHeader = "Authorization"
+
+func AuthHandleMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Authorization ヘッダを確認
+		authHeader := c.Request.Header.Get(AuthorizationHeader)
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, ecode.CodeJson("BlankAuthHeader"))
+			return
+		}
+		auth := strings.Split(authHeader, "Bearer ")
+		authLen := len(auth)
+		if authLen < 2 {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, ecode.CodeJson("InvalidAuthHeader"))
+			return
+		}
+		// Authorization Token を取得・検証
+		token := strings.TrimSpace(auth[authLen - 1])
+		claims, err := jwt.Verify(token)
+		if err != nil {
+			c.AbortWithError(http.StatusBadRequest, err).SetMeta(ecode.CodeJson("FailToValidateAuthToken"))
+			return
+		}
+		user, err := model.GetUser(
+			&model.UserGetQuery{ID: claims.UserID},
+			[]string{"id", "login", "email"},
+		)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, ecode.CodeJson("InvalidAuthToken"))
+			return
+		}
+		c.Set("CurrentUser", user)
+		log.Printf("[DEBUG] User#%d (%s)", user.ID, user.Login)
+
+		c.Next()
+	}
+}

--- a/back/src/middleware/error_handle.go
+++ b/back/src/middleware/error_handle.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"log"
+	
+	"github.com/gin-gonic/gin"
+)
+
+func ErrorHandleMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		if err := c.Errors.Last(); err != nil {
+			log.Printf("[ERROR] %v\n", err.Error())
+			if code, ok := err.Meta.(gin.H); ok {
+				c.JSON(c.Writer.Status(), code)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 概要
認証用のミドルウェアを追加しました。
(ユーザの認証を api ではなく、ミドルウェアで実施するようにしました)

また、存在しないユーザの更新に関する不具合を修正しました。
(存在しないユーザを指定した場合、例外を返却するようにいたしました)

### 仕様変更点
認証用ミドルウェアの追加に合わせて、以下の API を認証必須にしました。

-  `DELETE /v1/users/:id` (ユーザ削除)

## 確認事項
ユーザ削除に Authorization ヘッダ (認証) が必要となること

```
% curl -X DELETE 0.0.0.0:3000/v1/users/<id>
> {"code":"blank_authorization_header"}

% curl -X DELETE 0.0.0.0:3000/v1/users/<id> -H "Authorization: Bearer xxx.yyy.zzz"
> deleted
```