### PR TITLE
認証トークンの無効化

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -11,6 +11,7 @@ PUT    /v1/users/:id # ユーザ更新
 POST   /v1/users # ユーザ作成
 DELETE /v1/users/:id # ユーザ削除
 PUT    /v1/users/auth # ユーザ認証
+DELETE /v1/users/auth # ユーザ認証無効化
 ```
 
 #### 操作例

--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -71,6 +71,7 @@ func UpdateUser(c *gin.Context) {
 		return
 	}
 	userParams.ID = id
+	userParams.AuthUUID = nil
 	user, err := model.UpdateUser(&userParams)
 	if err != nil {
 		abortWithError(c, http.StatusBadRequest, "FailToUpdateUser", err)

--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -70,8 +70,7 @@ func UpdateUser(c *gin.Context) {
 		abortWithError(c, http.StatusBadRequest, "InvalidUpdateUserParams", err)
 		return
 	}
-	userParams.ID = id
-	userParams.AuthUUID = nil
+	userParams.ID, userParams.AuthUUID = id, nil
 	user, err := model.UpdateUser(&userParams)
 	if err != nil {
 		abortWithError(c, http.StatusBadRequest, "FailToUpdateUser", err)

--- a/back/src/cmd/app/main.go
+++ b/back/src/cmd/app/main.go
@@ -53,6 +53,8 @@ func serve() {
 	{
 		v1.GET("/users", api.ShowUsers)
 		v1.GET("/users/:id", api.ShowUser)
+		// TODO: ユーザ作成後と合わせて、認証もした方が良いかも ...
+		// TODO: 認証する場合、 token からユーザを取得する API が必要になりそう
 		v1.POST("/users", api.CreateUser)
 		v1.PUT("/users/auth", api.AuthUser)
 
@@ -62,6 +64,8 @@ func serve() {
 		{
 			auth.PUT("/users/:id", api.UpdateUser)
 			auth.DELETE("/users/:id", api.DeleteUser)
+			// TODO: 認証トークンの是非を問わず 204 を返却した方が良いかも ...
+			auth.DELETE("/users/auth", api.UnauthUser)
 		}
 	}
 

--- a/back/src/ecode/ecode.go
+++ b/back/src/ecode/ecode.go
@@ -12,7 +12,7 @@ var codeTable map[string]string = map[string]string{
 	"BlankAuthHeader"        : "blank_authorization_header",
 	"InvalidAuthHeader"      : "Invalid_authorization_header_format",
 	"FailToValidateAuthToken": "fail_to_validate_authorization_token",
-	"InvalidAuthToken"       : "invalid_authorization_token_format",
+	"InvalidAuthToken"       : "invalid_authorization_token",
 	"InvalidUpdateUserParams": "invalid_update_user_params",
 	"FailToUpdateUser"       : "fail_to_update_user",
 	"FailToDeleteUser"       : "fail_to_delete_user",
@@ -21,6 +21,9 @@ var codeTable map[string]string = map[string]string{
 	"BlankPassword"          : "blank_password",
 	"FailToAuth"             : "invalid_login_or_password",
 	"FailToGenerateAuthToken": "fail_to_generate_authorization_token",
+	"FailToGiveAuthToken"    : "fail_to_give_authorization_token",
+	"UnidentifiedUser"       : "unidentified_user",
+	"FailToDeleteAuthToken"  : "fail_to_delete_authorization_token",
 }
 
 func CodeJson(key string) gin.H {

--- a/back/src/middleware/auth.go
+++ b/back/src/middleware/auth.go
@@ -29,16 +29,16 @@ func AuthHandleMiddleware() gin.HandlerFunc {
 		}
 		// Authorization Token を取得・検証
 		token := strings.TrimSpace(auth[authLen - 1])
-		claims, err := jwt.Verify(token)
+		rjt, err := jwt.Verify(token)
 		if err != nil {
 			c.AbortWithError(http.StatusBadRequest, err).SetMeta(ecode.CodeJson("FailToValidateAuthToken"))
 			return
 		}
 		user, err := model.GetUser(
-			&model.UserGetQuery{ID: claims.UserID},
-			[]string{"id", "login", "email"},
+			&model.UserGetQuery{ID: rjt.UserID},
+			[]string{"id", "login", "email", "auth_uuid"},
 		)
-		if err != nil {
+		if err != nil || user.AuthUUID != rjt.ID {
 			c.AbortWithStatusJSON(http.StatusBadRequest, ecode.CodeJson("InvalidAuthToken"))
 			return
 		}

--- a/back/src/migrations/20220220090500_add_auth_uuid_to_users.down.sql
+++ b/back/src/migrations/20220220090500_add_auth_uuid_to_users.down.sql
@@ -1,0 +1,1 @@
+CALL `drop_column_if_exists`('users', 'auth_uuid');

--- a/back/src/migrations/20220220090500_add_auth_uuid_to_users.up.sql
+++ b/back/src/migrations/20220220090500_add_auth_uuid_to_users.up.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE IF EXISTS `setup_auth_uuid`;
+
+CREATE PROCEDURE `setup_auth_uuid` ()
+  BEGIN
+    IF NOT EXISTS (
+      SELECT * FROM `information_schema`.`columns` WHERE `table_name` = 'users' AND `column_name` = 'auth_uuid'
+    ) THEN
+      ALTER TABLE `users` ADD `auth_uuid` VARCHAR (255) NOT NULL DEFAULT "";
+    END IF;
+  END;
+
+CALL `setup_auth_uuid`;
+
+DROP PROCEDURE IF EXISTS `setup_auth_uuid`;

--- a/back/src/model/user.go
+++ b/back/src/model/user.go
@@ -26,15 +26,11 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
-type NewUser struct {
-	Login    string `json:"login,omitempty"`
-	Password string `json:"password,omitempty"`
-	Email    string `json:"email,omitempty"`
-}
-
 type User struct {
-	NewUser
 	ID                uint64 `json:"id,omitempty",gorm:"primaryKey"`
+	Login             string `json:"login,omitempty"`
+	Password          string `json:"password,omitempty"`
+	Email             string `json:"email,omitempty"`
 	PasswordSalt      string `json:"password_salt,omitempty"`
 	EncryptedPassword string `json:"encrypted_password,omitempty"`
 	AuthUUID          string `json:"auth_uuid,omitempty"`

--- a/back/src/model/user.go
+++ b/back/src/model/user.go
@@ -123,9 +123,7 @@ func CreateUser(userParams *UserParams) (*User, error) {
 	// TODO: 検証
 	user := &User{}
 	bindParamsToUser(userParams, user)
-	user.ID = 0
-	user.AuthUUID = ""
-
+	user.ID, user.AuthUUID = 0, ""
 	if err := conn.DB().Omit("Password").Create(user).Error; err != nil {
 		return nil, err
 	}
@@ -160,7 +158,6 @@ func DeleteUser(id uint64) error {
 		return err
 	}
 	defer conn.Close()
-
 	// TODO: 検証
 	if err := conn.DB().Delete(&User{ID: id}).Error; err != nil {
 		return err


### PR DESCRIPTION
## 概要
認証トークンを無効にする API を追加しました。

```
DELETE /v1/users/auth
```

#### 仕様
削除したい認証トークンを Authorization ヘッダとしてしてください。
ヘッダで指定されたトークンに対応するユーザの認証が無効となります。

##### 操作例
```
# トークン取得
curl -X PUT 0.0.0.0:3000/v1/users/auth -H "Content-Type: application/json" -d '{"login": <login>, "password": <password>}'
> xxx.yyy.zzz

# 認証が必要な処理を実行できる (e.g. ID が <id> であるユーザのパスワードを更新する)
curl -X PUT 0.0.0.0:3000/v1/users/<id> -H "Content-Type: application/json" -H "Authorization: Bearer xxx.yyy.zzz" -d '{"password": <password>}' 
> {"login": ... }

# トークン削除
curl -X DELETE 0.0.0.0:3000/v1/users/auth -H "Content-Type: application/json" -H "Authorization: Bearer xxx.yyy.zzz"

# 認証が必要な処理を実行できなくなる
curl -X PUT 0.0.0.0:3000/v1/users/<id> -H "Content-Type: application/json" -H "Authorization: Bearer xxx.yyy.zzz" -d '{"password": <password>}'
> {"code":"invalid_authorization_token"}
```

### その他
リクエストボディにおけるゼロ値の扱いを整理しました。
ユーザ更新時、メールアドレスなどに空文字を指定した場合、対象のユーザの属性は空として更新されます。

##### 操作例

```
# ID が <id> であるユーザのメールアドレスを空に更新する場合
curl -X PUT 0.0.0.0:3000/v1/users/<id> -H "Content-Type: application/json" -H "Authorization: Bearer xxx.yyy.zzz" -d '{"email": ""}'
>  {"login": ... }
```

## 確認事項
「操作例」のような動作が問題ないこと