### PR TITLE
レスポンスの制限

### DIFF
--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -48,7 +48,6 @@ func CreateUser(c *gin.Context) {
 		abortWithError(c, http.StatusBadRequest, "FailToCreateUser", err)
 		return
 	}
-	// TODO: 返却する field の選択
 	c.JSON(http.StatusCreated, user)
 }
 
@@ -70,7 +69,7 @@ func UpdateUser(c *gin.Context) {
 		abortWithError(c, http.StatusBadRequest, "InvalidUpdateUserParams", err)
 		return
 	}
-	userParams.ID, userParams.AuthUUID = id, nil
+	userParams.ID = id
 	user, err := model.UpdateUser(&userParams)
 	if err != nil {
 		abortWithError(c, http.StatusBadRequest, "FailToUpdateUser", err)

--- a/back/src/model/user.go
+++ b/back/src/model/user.go
@@ -31,9 +31,9 @@ type User struct {
 	Login             string `json:"login,omitempty"`
 	Password          string `json:"password,omitempty"`
 	Email             string `json:"email,omitempty"`
-	PasswordSalt      string `json:"password_salt,omitempty"`
-	EncryptedPassword string `json:"encrypted_password,omitempty"`
-	AuthUUID          string `json:"auth_uuid,omitempty"`
+	PasswordSalt      string `json:"-,omitempty"`
+	EncryptedPassword string `json:"-,omitempty"`
+	AuthUUID          string `json:"-,omitempty"`
 	CreatedAt         time.Time `json:"created_at,omitempty"`
 	UpdatedAt         time.Time `json:"updated_at,omitempty"`
 }
@@ -57,6 +57,7 @@ func (u *User) EncryptPassword() error {
 		return err
 	}
 	u.EncryptedPassword = digest
+	u.Password = ""
 	return nil
 }
 
@@ -111,7 +112,7 @@ type UserParams struct {
 	Login    *string `json:"login"`
 	Password *string `json:"password"`
 	Email    *string `json:"email"`
-	AuthUUID *string `json:"auth_uuid"`
+	AuthUUID *string `json:"-"`
 }
 
 func CreateUser(userParams *UserParams) (*User, error) {
@@ -123,7 +124,7 @@ func CreateUser(userParams *UserParams) (*User, error) {
 	// TODO: 検証
 	user := &User{}
 	bindParamsToUser(userParams, user)
-	user.ID, user.AuthUUID = 0, ""
+	user.ID = 0
 	if err := conn.DB().Omit("Password").Create(user).Error; err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func DeleteUser(id uint64) error {
 		return err
 	}
 	defer conn.Close()
-	// TODO: 検証
+	// TODO: 検証, 存在しないユーザの対策
 	if err := conn.DB().Delete(&User{ID: id}).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要
以下のフィールドを Users API のレスポンスに含まないようにいたしました。
センシティブなデータであるため、または内部的なデータであるためです。

- password
- password_salt
- encrypted_password
- auth_uuid

## 確認事項
ユーザ作成や更新などにて、上記の項目がレスポンスに含まれないこと。

```
# ユーザ作成
curl -X POST 0.0.0.0:3000/v1/users -H 'Content-Type: application/json' -d '{"login": "kor9", "password": "password1234", "email": "kor+9@sample.com"}'
{"id":23,"login":"kor9","email":"kor+9@sample.com","created_at":"2022-03-05T08:54:41.8434777Z","updated_at":"2022-03-05T08:54:41.8434777Z"}

# ユーザ更新
curl -X PUT 0.0.0.0:3000/v1/users/23 -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"password": "password12345"}'
{"id":23,"login":"kor9","email":"kor+9@sample.com","created_at":"2022-03-05T08:54:42Z","updated_at":"2022-03-05T08:57:39.6974502Z"}
```