### PR TITLE
レスポンスヘッダの追加

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -18,21 +18,24 @@ DELETE /v1/users/auth # ユーザ認証無効化
 
 ##### 疎通確認
 ```
-$ curl 0.0.0.0:3000/v1/ping 
-pong
+$ curl 0.0.0.0:3000/v1/ping
+> pong
 ```
 
 ##### ユーザ操作
 ```
 # 作成
 $ curl -X POST 0.0.0.0:3000/v1/users -H 'Content-Type: application/json' -d '{"login": "user", "password": "user1234", "email": "user@example.com"}'
-{"login":"user","password":"user1234","email":"user@example.com","id":1,"created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
+> {"id":1,"login":"user","email":"user@example.com","created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
 
 # 取得
 $ curl 0.0.0.0:3000/v1/users/1
-{"login":"user","email":"user@example.com","id":1,"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z"}
+> {"id":1,"login":"user","email":"user@example.com","created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
 
 # 削除
-$ curl -X DELETE 0.0.0.0:3000/v1/users/1
-deleted
+$ curl -X DELETE -H 'Authorization: Bearer <token>' 0.0.0.0:3000/v1/users/1
+
+# 認証
+$ curl -X PUT -H 0.0.0.0:3000/v1/users/1/auth -H 'Content-Type: application/json' -d '{"login": "user", "password": "user1234"}'
+> <token>
 ```

--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/SongCastle/KoR/lib/jwt"
+	"github.com/SongCastle/KoR/middleware"
 	"github.com/SongCastle/KoR/model"
 	"github.com/gin-gonic/gin"
 )
@@ -48,6 +49,18 @@ func CreateUser(c *gin.Context) {
 		abortWithError(c, http.StatusBadRequest, "FailToCreateUser", err)
 		return
 	}
+	// JWT Token 生成
+	jt, err := jwt.Generate(user.AuthUUID, user.Login, user.ID)
+	if err != nil {
+		abortWithError(c, http.StatusBadRequest, "FailToGenerateAuthToken", err)
+		return
+	}
+	if _, err:= model.UpdateUser(&model.UserParams{ID: user.ID, AuthUUID: &jt.ID}); err != nil {
+		abortWithError(c, http.StatusBadRequest, "FailToGiveAuthToken", err)
+		return
+	}
+	// Token をヘッダへセット
+	c.Header(middleware.TokenHeader, jt.Token)
 	c.JSON(http.StatusCreated, user)
 }
 

--- a/back/src/cmd/app/main.go
+++ b/back/src/cmd/app/main.go
@@ -53,8 +53,6 @@ func serve() {
 	{
 		v1.GET("/users", api.ShowUsers)
 		v1.GET("/users/:id", api.ShowUser)
-		// TODO: ユーザ作成後と合わせて、認証もした方が良いかも ...
-		// TODO: 認証する場合、 token からユーザを取得する API が必要になりそう
 		v1.POST("/users", api.CreateUser)
 		v1.PUT("/users/auth", api.AuthUser)
 

--- a/back/src/middleware/auth.go
+++ b/back/src/middleware/auth.go
@@ -11,7 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const AuthorizationHeader = "Authorization"
+const (
+	AuthorizationHeader = "Authorization" // Request Header
+	TokenHeader = "X-Authorization-Token" // Response Header
+)
 
 func AuthHandleMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -44,6 +47,7 @@ func AuthHandleMiddleware() gin.HandlerFunc {
 		}
 		c.Set("CurrentUser", user)
 		log.Printf("[DEBUG] User#%d (%s)", user.ID, user.Login)
+		c.Header(TokenHeader, token)
 
 		c.Next()
 	}


### PR DESCRIPTION
## 概要
特定の条件下にて、レスポンスヘッダ (`X-Authorization-Token`) へ認証トークンをセットするようにしました。

ユーザ作成 (サインアップ) 後に、認証を確立することが主な目的となります。

#### 条件

- 認証が要求される API へアクセスした場合
  - `PUT    /v1/users/:id`
  - `DELETE /v1/users/:id`
  - `DELETE /v1/users/auth`
- ユーザ作成 API をリクエストした場合
  - `POST   /v1/users` 

## 確認事項
上記の条件下で、レスポンスヘッダに `X-Authorization-Token` が含まれること

```
# ユーザ作成
$ curl -X POST 0.0.0.0:3000/v1/users --dump-header - -H "Content-Type: application/json" -d '{"login": "kor11", "password": "password1234"}'
HTTP/1.1 201 Created
Content-Type: application/json; charset=utf-8
X-Authorization-Token: <xxx.yyy.zzz> # 認証トークンが返却される
Date: Sun, 06 Mar 2022 18:48:54 GMT
Content-Length: 113

{"id":28,"login":"kor11","created_at":"2022-03-06T18:48:54.0362775Z","updated_at":"2022-03-06T18:48:54.0362775Z"}

# ユーザ更新
$ curl -X PUT 0.0.0.0:3000/v1/users/28 --dump-header - -H 'Authorization: Bearer <xxx.yyy.zzz>' -H 'Content-Type: application/json' -d '{"password": "password1234"}'
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
X-Authorization-Token: <xxx.yyy.zzz> # 認証トークンが返却される
Date: Sun, 06 Mar 2022 19:13:44 GMT
Content-Length: 105

{"id":28,"login":"kor11","created_at":"2022-03-06T18:48:54Z","updated_at":"2022-03-06T19:13:44.2916399Z"}
```