### PR TITLE
ユーザの検証を追加

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -18,21 +18,24 @@ DELETE /v1/users/auth # ユーザ認証無効化
 
 ##### 疎通確認
 ```
-$ curl 0.0.0.0:3000/v1/ping 
-pong
+$ curl 0.0.0.0:3000/v1/ping
+> pong
 ```
 
 ##### ユーザ操作
 ```
 # 作成
 $ curl -X POST 0.0.0.0:3000/v1/users -H 'Content-Type: application/json' -d '{"login": "user", "password": "user1234", "email": "user@example.com"}'
-{"login":"user","password":"user1234","email":"user@example.com","id":1,"created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
+> {"id":1,"login":"user","email":"user@example.com","created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
 
 # 取得
 $ curl 0.0.0.0:3000/v1/users/1
-{"login":"user","email":"user@example.com","id":1,"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z"}
+> {"id":1,"login":"user","email":"user@example.com","created_at":"2022-01-15T10:50:20.3272622Z","updated_at":"2022-01-15T10:50:20.3272622Z"}
 
 # 削除
-$ curl -X DELETE 0.0.0.0:3000/v1/users/1
-deleted
+$ curl -X DELETE -H 'Authorization: Bearer <token>' 0.0.0.0:3000/v1/users/1
+
+# 認証
+$ curl -X PUT -H 0.0.0.0:3000/v1/users/1/auth -H 'Content-Type: application/json' -d '{"login": "user", "password": "user1234"}'
+> <token>
 ```

--- a/back/src/api/users.go
+++ b/back/src/api/users.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/SongCastle/KoR/lib/jwt"
+	"github.com/SongCastle/KoR/middleware"
 	"github.com/SongCastle/KoR/model"
 	"github.com/gin-gonic/gin"
 )
@@ -48,6 +49,18 @@ func CreateUser(c *gin.Context) {
 		abortWithError(c, http.StatusBadRequest, "FailToCreateUser", err)
 		return
 	}
+	// JWT Token 生成
+	jt, err := jwt.Generate(user.AuthUUID, user.Login, user.ID)
+	if err != nil {
+		abortWithError(c, http.StatusBadRequest, "FailToGenerateAuthToken", err)
+		return
+	}
+	if _, err:= model.UpdateUser(&model.UserParams{ID: user.ID, AuthUUID: &jt.ID}); err != nil {
+		abortWithError(c, http.StatusBadRequest, "FailToGiveAuthToken", err)
+		return
+	}
+	// Token をヘッダへセット
+	c.Header(middleware.TokenHeader, jt.Token)
 	c.JSON(http.StatusCreated, user)
 }
 

--- a/back/src/cmd/app/main.go
+++ b/back/src/cmd/app/main.go
@@ -53,8 +53,6 @@ func serve() {
 	{
 		v1.GET("/users", api.ShowUsers)
 		v1.GET("/users/:id", api.ShowUser)
-		// TODO: ユーザ作成後と合わせて、認証もした方が良いかも ...
-		// TODO: 認証する場合、 token からユーザを取得する API が必要になりそう
 		v1.POST("/users", api.CreateUser)
 		v1.PUT("/users/auth", api.AuthUser)
 

--- a/back/src/db/config.go
+++ b/back/src/db/config.go
@@ -58,6 +58,6 @@ func (c *MySQLConf) Driver() string {
 func (c *MySQLConf) URL() string {
 	return fmt.Sprintf(
 		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
-		c.userName,	c.password, c.host, c.port, c.dbName,
+		c.userName, c.password, c.host, c.port, c.dbName,
 	)
 }

--- a/back/src/db/connection.go
+++ b/back/src/db/connection.go
@@ -6,6 +6,11 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+func newConnection() *Connection {
+	c := newClient()
+	return &Connection{client: c, idledAt: time.Now(), Available: true}
+}
+
 type Connection struct {
 	client    *MySQLClient
 	idledAt   time.Time
@@ -32,9 +37,4 @@ func (c *Connection) Fresh() error {
 
 func (c *Connection) DB() (*gorm.DB, error) {
 	return c.client.Connect()
-}
-
-func newConnection() *Connection {
-	c := newClient()
-	return &Connection{client: c, idledAt: time.Now(), Available: true}
 }

--- a/back/src/db/pool.go
+++ b/back/src/db/pool.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"errors"
-	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -32,7 +32,7 @@ func invoke() {
 				for i, c := range pool {
 					if !(c == nil || c.Active()) {
 						mu.Lock()
-						fmt.Printf("Reset Connection (err: %v)\n", c.Fresh())
+						log.Printf("Reset Connection %d (err: %v)\n", i, c.Fresh())
 						pool[i] = nil
 						mu.Unlock()
 					}

--- a/back/src/middleware/auth.go
+++ b/back/src/middleware/auth.go
@@ -11,7 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const AuthorizationHeader = "Authorization"
+const (
+	AuthorizationHeader = "Authorization" // Request Header
+	TokenHeader = "X-Authorization-Token" // Response Header
+)
 
 func AuthHandleMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -44,6 +47,7 @@ func AuthHandleMiddleware() gin.HandlerFunc {
 		}
 		c.Set("CurrentUser", user)
 		log.Printf("[DEBUG] User#%d (%s)", user.ID, user.Login)
+		c.Header(TokenHeader, token)
 
 		c.Next()
 	}

--- a/back/src/model/user.go
+++ b/back/src/model/user.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/SongCastle/KoR/lib/encryptor"
@@ -9,6 +10,14 @@ import (
 
 // password_salt の長さ
 const UserPasswordSaltLen = 32
+
+type UserParams struct {
+	ID       uint64
+	Login    *string `json:"login"`
+	Password *string `json:"password"`
+	Email    *string `json:"email"`
+	AuthUUID *string `json:"-"`
+}
 
 type User struct {
 	ID                uint64 `json:"id,omitempty",gorm:"primaryKey"`
@@ -42,4 +51,45 @@ func (u *User) EncryptPassword() error {
 
 func (u *User) ValidPassword(password string) bool {
 	return encryptor.Compare(u.EncryptedPassword, password + u.PasswordSalt)
+}
+
+func (u *User) BindParams(params *UserParams) {
+	bindParamsToObject(params, u)
+}
+
+func bindParamsToObject(params interface{}, obj interface{}) {
+	vp := reflect.ValueOf(params)
+	ivp := reflect.Indirect(vp)
+	// 引数が nil ポインタである、または非参照型である (Elem 取得不可)
+	if !ivp.IsValid() || vp == ivp {
+		return
+	}
+	vo := reflect.ValueOf(obj)
+	ivo := reflect.Indirect(vo)
+	if !ivo.IsValid() || vo == ivo {
+		return
+	}
+	rp, ro := vp.Elem(), vo.Elem()
+	rpt := rp.Type()
+	for i := 0; i < rpt.NumField(); i++ {
+		// params のフィールド名を取得
+		fn := rpt.Field(i).Name
+		if v := rp.FieldByName(fn); !v.IsZero() {
+			// obj に同じフィールドがあるか確認
+			if v2 := ro.FieldByName(fn); v2 != (reflect.Value{}) {
+				if v.Kind() == v2.Kind() {
+					// 同じ型のフィールドが存在する場合、値をセットする
+					v2.Set(v)
+				} else {
+					// 型が違う場合、ポインタの参照先を確認する
+					if iv := reflect.Indirect(v); iv.IsValid() {
+						// 参照先の型が同じ型である場合、値をセットする
+						if iv.Kind() == v2.Kind() {
+							v2.Set(iv)
+						}
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## 概要
ユーザ操作時 (作成・更新) の検証を追加しました。

### 変更点
- 重複したログイン名 (login) の登録を禁止しました
- 空のパスワードへ更新しようとした場合、エラーを返却する様にしました
- パスワードの最大長を制限しました (password + salt + pepper <= 72 bytes)

## 確認事項
変更点に抵触するような操作時、 400 となること

```
# 重複したログイン名の登録ができない
$ curl -X POST 0.0.0.0:3000/v1/users -H "Content-Type: application/json" -d '{"login": "kor12", "password": "password1234"}'
> {"id":32,"login":"kor12","created_at":"2022-03-08T00:39:19.3417147Z","updated_at":"2022-03-08T00:39:19.3417147Z"}
$ curl -X POST 0.0.0.0:3000/v1/users -H "Content-Type: application/json" -d '{"login": "kor12", "password": "password1234"}'
> {"code":"fail_to_create_user"}

# 空のパスワードへ更新できない
$ curl -X PUT 0.0.0.0:3000/v1/users/32 -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"password": ""}' 
> {"code":"fail_to_update_user"}

# 長いパスワードへ更新できない
$ curl -X PUT 0.0.0.0:3000/v1/users/32 -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"password": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
> {"code":"fail_to_update_user"}
```