### PR TITLE
パスワードのハッシュ化方式の変更

### DIFF
--- a/back/src/api/model/user.go
+++ b/back/src/api/model/user.go
@@ -49,7 +49,6 @@ func (u *User) ValidateLogin() error {
 	if err != nil {
 		return err
 	}
-	// TODO: DB 制約の検討
 	if exist {
 		return errors.New("Duplicate Login")
 	}

--- a/back/src/internal/encryptor/argon2id/argon2id.go
+++ b/back/src/internal/encryptor/argon2id/argon2id.go
@@ -1,0 +1,98 @@
+package argon2id
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+
+	"github.com/SongCastle/KoR/internal/random"
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	Version     = argon2.Version
+	Memory      = uint32(32 << 10) // 32 MiB
+	TimeCost    = uint32(3)
+	Parallelism = uint8(4)
+	KeyLen      = uint32(32)
+	SaltLen     = uint32(32)
+	HashFormat  = "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s"
+)
+
+var (
+	Encoder   *base64.Encoding = base64.RawStdEncoding
+	Decoder   *base64.Encoding = Encoder.Strict()
+	Regex     *regexp.Regexp   = regexp.MustCompile(`^\$argon2id`)
+	HashRegex *regexp.Regexp   = regexp.MustCompile(`^\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$([[:alnum:]+/]+)\$([[:alnum:]+/]+)$`)
+	InvalidHashFormat error    = errors.New("invalid_hash_format")
+	InvalidComplexity error    = errors.New("invalid_complexityt")
+)
+
+type rawHash struct {
+	salt, hash []byte
+}
+
+func Digest(password string) (string, error) {
+	salt := []byte(random.Generate(int(SaltLen)))
+	hash := argon2.IDKey(
+		[]byte(password), salt, TimeCost, Memory, Parallelism, KeyLen,
+	)
+	return fmt.Sprintf(
+		HashFormat,
+		Version, Memory, TimeCost, Parallelism,
+		Encoder.EncodeToString(salt), Encoder.EncodeToString(hash),
+	), nil
+}
+
+func Compare(hash, password string) bool {
+	raw, err := decodeHash(hash)
+	if err != nil {
+		log.Printf("argon2id Compare Error: %v\n", err)
+		return false
+	}
+	calcHash := argon2.IDKey(
+		[]byte(password), raw.salt, TimeCost, Memory, Parallelism, KeyLen,
+	)
+	return subtle.ConstantTimeCompare([]byte(raw.hash), calcHash) == 1
+}
+
+func EncryptedByArgon2id(hash string) bool {
+	return Regex.MatchString(hash)
+}
+
+func decodeHash(hash string) (*rawHash, error) {
+	keys := HashRegex.FindStringSubmatch(hash)
+	if len(keys) != 7 {
+		return nil, InvalidHashFormat
+	}
+	if v, err := strconv.Atoi(keys[1]); v != Version || err != nil {
+		return nil, InvalidComplexity
+	}
+	if m, err := strconv.Atoi(keys[2]); uint32(m) != Memory || err != nil {
+		return nil, InvalidComplexity
+	}
+	if t, err := strconv.Atoi(keys[3]); uint32(t) != TimeCost || err != nil {
+		return nil, InvalidComplexity
+	}
+	if p, err := strconv.Atoi(keys[4]); uint8(p) != Parallelism || err != nil {
+		return nil, InvalidComplexity
+	}
+	var err error
+	raw := &rawHash{}
+	raw.salt, err = Decoder.DecodeString(keys[5])
+	if err != nil {
+		return nil, err
+	}
+	raw.hash, err = Decoder.DecodeString(keys[6])
+	if err != nil {
+		return nil, err
+	}
+	if uint32(len(raw.hash)) != KeyLen {
+		return nil, InvalidComplexity
+	}
+	return raw, nil
+}

--- a/back/src/internal/encryptor/bcrypt/bcrypt.go
+++ b/back/src/internal/encryptor/bcrypt/bcrypt.go
@@ -1,0 +1,36 @@
+package bcrypt
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const maxPasswordByteSize = 72
+
+var (
+	Cost         int   = bcrypt.DefaultCost
+	TooLongError error = errors.New("Too Long")
+)
+
+func Digest(password string) (string, error) {
+	if tooLongPassword(password) {
+		return "", TooLongError
+	}
+	digest, err := bcrypt.GenerateFromPassword([]byte(password), Cost)
+	if err == nil {
+		return string(digest), nil
+	}
+	return "", err
+}
+
+func Compare(digest, password string) bool {
+	if tooLongPassword(password) {
+		return false
+	}
+	return bcrypt.CompareHashAndPassword([]byte(digest), []byte((password))) == nil
+}
+
+func tooLongPassword(password string) bool {
+	return len(password) > maxPasswordByteSize
+}

--- a/back/src/internal/random/random.go
+++ b/back/src/internal/random/random.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	// TODO: "crypto/rand" にする
 	"math/rand"
 	"time"
 	"strconv"

--- a/back/src/volume/db/connection.go
+++ b/back/src/volume/db/connection.go
@@ -7,8 +7,11 @@ import (
 )
 
 func newConnection() *Connection {
-	c := newClient()
-	return &Connection{client: c, idledAt: time.Now(), Available: true}
+	return &Connection{
+		client: newClient(),
+		idledAt: time.Now(),
+		Available: true,
+	}
 }
 
 type Connection struct {


### PR DESCRIPTION
## 概要
パスワードのハッシュ化方式を変更いたしました。
72 bytes 超のパスワードに対応したいためとなります。

変更前|変更後
:-:|:-:
BCrypt|Argon2id

後方互換のため、すでに作成済みのユーザは BCrypt にて検証しています。
パスワードを変更した場合、それ以降は Argon2id が利用されます。
(新規ユーザのパスワードは Argon2id によりハッシュ化しています)

参考: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

## 確認事項
72 bytes 超のパスワードを保存できること

```
# パスワードが 100 文字 (bytes) のユーザを作成する
$ curl -X POST 0.0.0.0:3000/v1/users -H 'Content-Type: application/json' -d '{"login": "kor14", "password": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' 
{"id":41,"login":"kor14","created_at":"2022-03-11T19:33:45.1937539Z","updated_at":"2022-03-11T19:33:45.1937539Z"}

# ↑ で作成したユーザで認証する
$ curl -X PUT 0.0.0.0:3000/v1/users/auth -H 'Content-Type: application/json' -d '{"login": "kor14", "password": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
> xxx.yyy.xxx (token)
```