### PR TITLE
乱数生成方法の変更

### DIFF
--- a/back/src/internal/encryptor/argon2id/argon2id.go
+++ b/back/src/internal/encryptor/argon2id/argon2id.go
@@ -57,7 +57,7 @@ func Compare(hash, password string) bool {
 	calcHash := argon2.IDKey(
 		[]byte(password), raw.salt, TimeCost, Memory, Parallelism, KeyLen,
 	)
-	return subtle.ConstantTimeCompare([]byte(raw.hash), calcHash) == 1
+	return subtle.ConstantTimeCompare(raw.hash, calcHash) == 1
 }
 
 func EncryptedByArgon2id(hash string) bool {

--- a/back/src/internal/encryptor/argon2id/argon2id.go
+++ b/back/src/internal/encryptor/argon2id/argon2id.go
@@ -29,7 +29,7 @@ var (
 	Regex     *regexp.Regexp   = regexp.MustCompile(`^\$argon2id`)
 	HashRegex *regexp.Regexp   = regexp.MustCompile(`^\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$([[:alnum:]+/]+)\$([[:alnum:]+/]+)$`)
 	InvalidHashFormat error    = errors.New("invalid_hash_format")
-	InvalidComplexity error    = errors.New("invalid_complexityt")
+	InvalidComplexity error    = errors.New("invalid_complexity")
 )
 
 type rawHash struct {

--- a/back/src/internal/random/random.go
+++ b/back/src/internal/random/random.go
@@ -1,18 +1,37 @@
 package random
 
 import (
-	// TODO: "crypto/rand" にする
-	"math/rand"
-	"time"
+	"crypto/rand"
+	"encoding/base64"
+	mrand "math/rand"
 	"strconv"
+	"time"
 )
 
+var Encoder *base64.Encoding = base64.RawStdEncoding
+
 func Generate(len int) string {
-	rand.Seed(time.Now().UnixNano())
+	if r, err := generateStrongly(len); err == nil {
+		return r
+	}
+	return generateWeakly(len)
+}
+
+func generateStrongly(len int) (string, error) {
+	b := make([]byte, len)
+	_, err := rand.Read(b)
+	if err == nil {
+		return Encoder.EncodeToString(b)[:len], nil
+	}
+	return "", err
+}
+
+func generateWeakly(len int) string {
+	mrand.Seed(time.Now().UnixNano())
 
 	word := ""
 	for i := 0; i < len; i++ {
-		n := rand.Intn(62)
+		n := mrand.Intn(62)
 		if n < 26 {
 			// 小文字
 			word += string('a' + n)


### PR DESCRIPTION
## 概要
乱数の生成方法を変更しました。
乱数の強度を高めたいためとなります。

変更前|変更後
:-:|:-:
`"math/rand"`<br>(時間を元にした疑似乱数)|`"crypto/rand"`<br>(ハードのノイズ ? などを元にした疑似乱数)

## 確認事項
ユーザの作成・認証などが問題ないこと

```
# ユーザ作成
$ curl -X POST 0.0.0.0:3000/v1/users -H 'Content-Type: application/json' -d '{"login": "kor15", "password": "password1234"}'                                                                                        
> {"id":44,"login":"kor15","created_at":"2022-03-11T21:23:22.8173587Z","updated_at":"2022-03-11T21:23:22.8173587Z"}

# ユーザ認証
$ curl -X PUT 0.0.0.0:3000/v1/users/auth -H 'Content-Type: application/json' -d '{"login": "kor15", "password": "password1234"}'
> xxx.yyy.zzz (token)
```