### PR TITLE
`auth_uuid` カラムの削除

### DIFF
--- a/back/src/volume/db/migrations/20220327101436_remove_auth_uuid_from_users.down.sql
+++ b/back/src/volume/db/migrations/20220327101436_remove_auth_uuid_from_users.down.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE IF EXISTS `setup_auth_uuid`;
+
+CREATE PROCEDURE `setup_auth_uuid` ()
+  BEGIN
+    IF NOT EXISTS (
+      SELECT * FROM `information_schema`.`columns` WHERE `table_name` = 'users' AND `column_name` = 'auth_uuid'
+    ) THEN
+      ALTER TABLE `users` ADD `auth_uuid` VARCHAR (255) NOT NULL DEFAULT "";
+    END IF;
+  END;
+
+CALL `setup_auth_uuid`;
+
+DROP PROCEDURE IF EXISTS `setup_auth_uuid`;

--- a/back/src/volume/db/migrations/20220327101436_remove_auth_uuid_from_users.up.sql
+++ b/back/src/volume/db/migrations/20220327101436_remove_auth_uuid_from_users.up.sql
@@ -1,0 +1,1 @@
+CALL `drop_column_if_exists`('users', 'auth_uuid');


### PR DESCRIPTION
## 概要
`users` テーブルの `auth_uuid` カラムを削除しました。
#16 にて、`auth_uuid` カラムの代替となる `tokens` , `authorities` テーブルを作成しているためとなります。

## 動作確認
ユーザの認証機構が問題ないこと

- `POST /v1/users/token`
- `DELETE /v1/users/token`
- `POST /v1/users/admin/token`

## 補足
本 PR マージ前に、 #16 の「マイグレーション」を実施する必要があります。